### PR TITLE
Fix file processing

### DIFF
--- a/WPAPlugin/Properties/launchSettings.json
+++ b/WPAPlugin/Properties/launchSettings.json
@@ -3,12 +3,12 @@
     "Debug": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files (x86)\\Windows Kits\\10\\Windows Performance Toolkit\\wpa.exe",
-      "commandLineArgs": "-nodefault -addsearchdir \"%USERPROFILE%\\devProjects\\wpa-plugin\\WPAPlugin\\bin\\Debug\\netstandard2.0\""
+      "commandLineArgs": "-nodefault -addsearchdir \"%USERPROFILE%\\devProjects\\windowsperf-wpa-plugin\\WPAPlugin\\bin\\Debug\\netstandard2.0\""
     },
     "Release": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files (x86)\\Windows Kits\\10\\Windows Performance Toolkit\\wpa.exe",
-      "commandLineArgs": "-nodefault -addsearchdir \"%USERPROFILE%\\devProjects\\wpa-plugin\\WPAPlugin\\bin\\Release\\netstandard2.0\""
+      "commandLineArgs": "-nodefault -addsearchdir \"%USERPROFILE%\\devProjects\\windowsperf-wpa-plugin\\WPAPlugin\\bin\\Release\\netstandard2.0\""
     }
   }
 }

--- a/WPAPlugin/WPAPlugin.csproj
+++ b/WPAPlugin/WPAPlugin.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>1.0.2</AssemblyVersion>
-    <FileVersion>1.0.2</FileVersion>
+    <AssemblyVersion>1.0.3</AssemblyVersion>
+    <FileVersion>1.0.3</FileVersion>
     <Version>1.0.2</Version>
   </PropertyGroup>
 

--- a/WPAPlugin/WPAPlugin.csproj
+++ b/WPAPlugin/WPAPlugin.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyVersion>1.0.3</AssemblyVersion>
     <FileVersion>1.0.3</FileVersion>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WPAPlugin/WperfProcessingSourceWithSourceParser.cs
+++ b/WPAPlugin/WperfProcessingSourceWithSourceParser.cs
@@ -96,15 +96,13 @@ namespace WPAPlugin
         {
             WperfSourceParser parser = new WperfSourceParser(timelinePathList, countingPathList);
 
-            var _cachedProcessor = new WperfCustomDataProcessorWithSourceParser(
+            validationCache.Clear();
+            return new WperfCustomDataProcessorWithSourceParser(
                 parser,
                 options,
                 applicationEnvironment,
                 processorEnvironment
             );
-
-            validationCache.Clear();
-            return _cachedProcessor;
         }
 
         private static Dictionary<(string, string), bool> validationCache =

--- a/WPAPlugin/WperfProcessingSourceWithSourceParser.cs
+++ b/WPAPlugin/WperfProcessingSourceWithSourceParser.cs
@@ -31,7 +31,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Microsoft.Performance.SDK.Processing;
 using NJsonSchema;
 using WPAPlugin.Schemas;
@@ -50,6 +49,9 @@ namespace WPAPlugin
     public class WperfProcessingSourceWithSourceParser : ProcessingSource
     {
         private IApplicationEnvironment applicationEnvironment;
+
+        public WperfProcessingSourceWithSourceParser()
+            : base() { }
 
         /// <summary>
         /// Sets project information
@@ -92,20 +94,17 @@ namespace WPAPlugin
             ProcessorOptions options
         )
         {
-            WperfSourceParser parser = new WperfSourceParser(
-                timelinePathList.ToArray(),
-                countingPathList.ToArray()
-            );
+            WperfSourceParser parser = new WperfSourceParser(timelinePathList, countingPathList);
 
-            timelinePathList.Clear();
-            countingPathList.Clear();
-            validationCache.Clear();
-            return new WperfCustomDataProcessorWithSourceParser(
+            var _cachedProcessor = new WperfCustomDataProcessorWithSourceParser(
                 parser,
                 options,
                 applicationEnvironment,
                 processorEnvironment
             );
+
+            validationCache.Clear();
+            return _cachedProcessor;
         }
 
         private static Dictionary<(string, string), bool> validationCache =

--- a/WPAPlugin/WperfSourceParser.cs
+++ b/WPAPlugin/WperfSourceParser.cs
@@ -47,15 +47,18 @@ namespace WPAPlugin
     /// </summary>
     public class WperfSourceParser : ISourceParser<WperfEvent, WperfSourceParser, string>
     {
-        private readonly string[] timelineFilesPathList;
-        private readonly string[] countFilesPathList;
+        private readonly HashSet<string> timelineFilesPathList;
+        private readonly HashSet<string> countFilesPathList;
 
         /// <summary>
         /// Timeline and count files paths lists need to be passed seperately to the <c>constructor</c>
         /// </summary>
         /// <param name="timelineFilesPathList">List of timeline file paths</param>
         /// <param name="countFilesPathList">List of single count file paths</param>
-        public WperfSourceParser(string[] timelineFilesPathList, string[] countFilesPathList)
+        public WperfSourceParser(
+            HashSet<string> timelineFilesPathList,
+            HashSet<string> countFilesPathList
+        )
         {
             this.timelineFilesPathList = timelineFilesPathList;
             this.countFilesPathList = countFilesPathList;
@@ -96,7 +99,7 @@ namespace WPAPlugin
             CancellationToken cancellationToken
         )
         {
-            int filesCount = timelineFilesPathList.Length;
+            int filesCount = timelineFilesPathList.Count;
             if (filesCount == 0)
             {
                 return;
@@ -211,7 +214,7 @@ namespace WPAPlugin
             CancellationToken cancellationToken
         )
         {
-            int filesCount = countFilesPathList.Length;
+            int filesCount = countFilesPathList.Count;
             if (filesCount == 0)
             {
                 return;
@@ -312,6 +315,8 @@ namespace WPAPlugin
         {
             ProcessTimelineFiles(dataProcessor, cancellationToken);
             ProcessCountFiles(dataProcessor, cancellationToken);
+            this.timelineFilesPathList.Clear();
+            this.countFilesPathList.Clear();
         }
     }
 }


### PR DESCRIPTION
Newer versions of WPA are calling `CreateProcessorCore` twice (once for table discovery, once for processing) so the input file path list was being cleared before processing.

This change aims to move clearing the input paths `Hashset` after processing is done